### PR TITLE
fix: improve the logic to filter emojis by keyword

### DIFF
--- a/lib/src/data/emoji_data.dart
+++ b/lib/src/data/emoji_data.dart
@@ -87,7 +87,10 @@ class EmojiData with _$EmojiData {
       final filteredEmojiIds = <String>[];
       for (final emojiId in category.emojiIds) {
         final emoji = emojis[emojiId]!;
-        if (emoji.keywords.any((k) => k.contains(keyword.toLowerCase()))) {
+        final lowercaseKey = keyword.toLowerCase();
+        if (emoji.keywords.any((k) => k.contains(lowercaseKey)) ||
+            emoji.id.contains(lowercaseKey) ||
+            emoji.name.contains(lowercaseKey)) {
           filteredEmojiIds.add(emojiId);
           filteredEmojis[emojiId] = emoji;
         }


### PR DESCRIPTION
Improve the logic to filter emojis by keyword

Before: 

https://github.com/user-attachments/assets/18b5db9f-e6f7-4296-aa76-eedc9d27e8e3

After: 


https://github.com/user-attachments/assets/df283ac8-0bad-498f-9e4d-e4c57947a4a9

